### PR TITLE
refactor: removes duplicate /api from controllers

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -5,7 +5,7 @@ import { Response } from 'express';
 @Controller()
 @ApiTags('App')
 export class AppController {
-  @Get('/api')
+  @Get()
   @ApiOperation({ summary: 'Redirect to swagger' })
   redirectToSwagger(@Res() res: Response) {
     res.redirect('/swagger');

--- a/src/financial/financial.controller.ts
+++ b/src/financial/financial.controller.ts
@@ -12,7 +12,7 @@ import { UserLimitDto } from './user-limit.dto';
 export class FinancialController {
   constructor(private readonly financialService: FinancialService) {}
 
-  @Get('/api/v1/financial/limits')
+  @Get('v1/financial/limits')
   @ApiResponse({ type: UserLimitDto })
   getLimits(@Req() { user: { uid } }: AuthenticatedRequest) {
     return this.financialService.checkUserLimit(uid);

--- a/src/machine/machine.controller.ts
+++ b/src/machine/machine.controller.ts
@@ -21,49 +21,49 @@ import { MachineService } from './machine.service';
 export class MachineController {
   constructor(private readonly machineService: MachineService) {}
 
-  @Get('/api/v1/machine/apps')
+  @Get('v1/machine/apps')
   @ApiBody({ type: MachineApp, isArray: true })
   getApps() {
     return this.machineService.getApps();
   }
 
-  @Post('/api/v1/machine/apps')
+  @Post('v1/machine/apps')
   @ApiBody({ type: AppTemplate })
   @ApiResponse({ type: MachineApp, isArray: true })
   installApp(@Body() template: AppTemplate) {
     return this.machineService.installApp(template);
   }
 
-  @Delete('/api/v1/machine/apps')
+  @Delete('v1/machine/apps')
   uninstallApps() {
     return this.machineService.uninstallApps();
   }
 
-  @Get('/api/v1/machine/apps/:appId')
+  @Get('v1/machine/apps/:appId')
   @ApiBody({ type: MachineApp, isArray: true })
   @ApiParam({ name: 'appId' })
   getApp(@Param('appId') appId: string) {
     return this.machineService.getApp(appId);
   }
 
-  @Delete('/api/v1/machine/apps/:appId')
+  @Delete('v1/machine/apps/:appId')
   @ApiBody({ type: MachineApp, isArray: true })
   @ApiParam({ name: 'appId' })
   uninstallApp(@Param('appId') appId: string) {
     return this.machineService.getApp(appId);
   }
 
-  @Post('/api/v1/machine/apps/:appId/start')
+  @Post('v1/machine/apps/:appId/start')
   startApp(@Param('appId') appId: string) {
     return this.machineService.startApp(appId);
   }
 
-  @Post('/api/v1/machine/apps/:appId/stop')
+  @Post('v1/machine/apps/:appId/stop')
   stopApp(@Param('appId') appId: string) {
     return this.machineService.startApp(appId);
   }
 
-  @Post('/api/v1/machine/apps/:appId/restart')
+  @Post('v1/machine/apps/:appId/restart')
   restartApp(@Param('appId') appId: string) {
     return this.machineService.restartApp(appId);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ export async function bootstrap() {
     logger: ['error', 'warn', 'verbose'],
   });
 
+  app.setGlobalPrefix('api'); // make all routes in api
+
   app.useLogger(app.get(LoggerService));
   app.useWebSocketAdapter(new WsAdapter(app) as any);
 

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -9,7 +9,7 @@ import { StoreService } from './store.service';
 export class StoreController {
   constructor(private readonly storeService: StoreService) {}
 
-  @Get('/api/v1/store/app-templates')
+  @Get('v1/store/app-templates')
   @ApiBody({ type: AppTemplate, isArray: true })
   getAppTemplates() {
     return this.storeService.getAppTemplates();

--- a/src/sysinfo/sysinfo.controller.ts
+++ b/src/sysinfo/sysinfo.controller.ts
@@ -14,28 +14,27 @@ import { SysinfoService } from './sysinfo.service';
 @UseGuards(ApiGuard)
 export class SysinfoController {
   constructor(private readonly sysInfoService: SysinfoService) {}
-
-  @Get('/api/v1/sysinfo/docker')
+  @Get('v1/sysinfo/docker')
   async docker() {
     return this.sysInfoService.docker();
   }
 
-  @Get('/api/v1/sysinfo/general')
+  @Get('v1/sysinfo/general')
   async general() {
     return this.sysInfoService.general();
   }
 
-  @Get('/api/v1/sysinfo/ip')
+  @Get('v1/sysinfo/ip')
   async ip() {
     return this.sysInfoService.ip();
   }
 
-  @Get('/api/v1/sysinfo/geo-ip')
+  @Get('v1/sysinfo/geo-ip')
   async geoIp() {
     return this.sysInfoService.geoIp();
   }
 
-  @Get('/api/v1/sysinfo/location.svg')
+  @Get('v1/sysinfo/location.svg')
   async geoMap(@Res() res: Response) {
     const { lon, lat } = await this.sysInfoService.geoIp();
 


### PR DESCRIPTION
I just remove the duplicate /API from controllers to make it more readable and added a global prefix instead of it in the main.ts. now the whole app runs on /api without typing it in controllers.

Can you check if it won't break anything?